### PR TITLE
bump dist-git branch name

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -23,4 +23,4 @@ dogen:
     plugins:
         dist_git:
             repo: jboss-base-docker
-            branch: jb-rhel7-1.0
+            branch: jb-rhel7-1.1


### PR DESCRIPTION
Update the dist-git branch name to match the version number.

This is necessary for rebuilding images properly now.