### PR TITLE
Move to RHEL7.5 base image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "jboss/base-rhel7"
 version: "1.2"
-from: "rhel7:7.4-released"
+from: "rhel7:7.5-released"
 description: "Base image for all other Middleware container images which provides common set of tools, jboss user and home directory"
 labels:
     - name: com.redhat.component


### PR DESCRIPTION
We've done this for the release branch but not for the dev branch

Nothing is using the dev branch anyway, but as long as we have it
we should probably keep it up to date.